### PR TITLE
Fix Unescaped Single Quotes

### DIFF
--- a/ffind/backports/argparse.py
+++ b/ffind/backports/argparse.py
@@ -2294,7 +2294,7 @@ class ArgumentParser(_AttributeHolder, _ActionsContainer):
     def format_version(self):
         import warnings
         warnings.warn(
-            'The format_version method is deprecated -- the 'version' '
+            'The format_version method is deprecated -- the \'version\' '
             'argument to ArgumentParser is no longer supported.',
             DeprecationWarning)
         formatter = self._get_formatter()


### PR DESCRIPTION
There were several places in the argparse.py file where single quotes in strings went un-escaped.  This made the installation process fail.  This branch holds the patch.
