### PR TITLE
Python3 compatibility

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ class ff_install(install):
                 cwd=man_dir,
                 env=dict({"PREFIX": self.prefix},
                          **dict(os.environ))).communicate()[0]
-        print output
+        print(output)
 
 
 setup(

--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,7 @@ class ff_install(install):
         output = subprocess.Popen([os.path.join(man_dir, "install.sh")],
                 stdout=subprocess.PIPE,
                 cwd=man_dir,
+                universal_newlines=True,
                 env=dict({"PREFIX": self.prefix},
                          **dict(os.environ))).communicate()[0]
         print(output)

--- a/setup.py
+++ b/setup.py
@@ -4,6 +4,8 @@ from distutils.command.install import install
 import os
 import subprocess
 
+from future import print_function
+
 
 def abspath(path):
     """A method to determine absolute path


### PR DESCRIPTION
Just changed a print statement to make `python3 setup.py install` work.

Otherwise, I've been using ffind with python 3.4 with no problems.