### PR TITLE
Add a FFIND_SORT environment variable to ensure sorted results

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 build
 .coverage
 htmlcov
+*.t.err

--- a/ffind/ffind.py
+++ b/ffind/ffind.py
@@ -51,6 +51,8 @@ VCS_FILES = ('=RELEASE-ID',
              '.cvsignore',
              '.gitignore',)
 
+SORT_RESULT = bool(os.environ.get('FFIND_SORT', '0'))
+
 
 class WrongPattern(Exception):
     pass
@@ -161,10 +163,13 @@ def search(directory, file_pattern, path_match,
 
     for root, sub_folders, files in os.walk(directory, topdown=True,
                                             followlinks=follow_symlinks):
-
+        if SORT_RESULT:
+            sub_folders.sort()
+            files.sort()
         # Ignore hidden and VCS directories.
         fsubfolders = filtered_subfolders(sub_folders, ignore_hidden,
                                           ignore_vcs)
+
         ffiles = filtered_files(files, ignore_hidden, ignore_vcs)
 
         # Search in files and subfolders

--- a/tests/regex.t
+++ b/tests/regex.t
@@ -5,7 +5,7 @@ Setup
 Run test
 
   $ $PYTHON $TESTDIR/../ffind/ffind.py py$
-  ./test_dir/test1.py
   ./test_dir/Test2.py
-  ./test_dir/second_level/stest1.py
+  ./test_dir/test1.py
   ./test_dir/second_level/sTest2.py
+  ./test_dir/second_level/stest1.py

--- a/tests/regex2.t
+++ b/tests/regex2.t
@@ -5,5 +5,5 @@ Setup
 Run test
 
   $ $PYTHON $TESTDIR/../ffind/ffind.py .test..py
-  ./test_dir/second_level/stest1.py
   ./test_dir/second_level/sTest2.py
+  ./test_dir/second_level/stest1.py

--- a/tests/setup.sh
+++ b/tests/setup.sh
@@ -17,3 +17,5 @@ touch $TEST_DIR/.git/config
 touch $TEST_DIR/.git/library
 mkdir $TEST_DIR/.venv
 mkdir $TEST_DIR/.venv/library
+
+FFIND_SORT=1


### PR DESCRIPTION
This is useful for tests, as filesystems can return different orderings